### PR TITLE
Renovate workflow: fall back to `github.token` when `RENOVATE_TOKEN` secret missing

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -19,6 +19,8 @@ jobs:
     steps:
       - name: Run Renovate
         uses: renovatebot/github-action@v43.0.14
+        env:
+          RENOVATE_TOKEN: ${{ secrets.RENOVATE_TOKEN || github.token }}
         with:
           configurationFile: renovate.json
-          token: ${{ secrets.RENOVATE_TOKEN }}
+          token: ${{ secrets.RENOVATE_TOKEN || github.token }}


### PR DESCRIPTION
### Motivation
- Allow the Renovate GitHub Action to run when a repository-specific `secrets.RENOVATE_TOKEN` is not configured by falling back to the built-in `github.token`.

### Description
- Added an `env` entry `RENOVATE_TOKEN: ${{ secrets.RENOVATE_TOKEN || github.token }}` and updated the action input `token` to use the same fallback in `.github/workflows/renovate.yml`.

### Testing
- No automated tests were run for this CI workflow change; the update will be validated when GitHub Actions executes the workflow.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a49262acf8832da49290aa49694303)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Renovate GitHub Action workflow configuration with enhanced token handling and automatic fallback support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->